### PR TITLE
fix plugin URL

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -14,7 +14,7 @@
       There are no options to configure for Organize Tab at this time.
     </p>
     <p>
-      <a href="https://www.hacktoolkit.com/organize-tabs-chrome-extension/" target="_blank">Learn More</a>
+      <a href="https://hacktoolkit.github.io/organize-tabs-chrome-extension/" target="_blank">Learn More</a>
     </p>
 
     <script src="vendor/jquery-3.5.1.min.js"></script>

--- a/src/popup.html
+++ b/src/popup.html
@@ -42,7 +42,7 @@
     </div>
 
     <p>
-      <a href="https://www.hacktoolkit.com/organize-tabs-chrome-extension/" target="_blank">Learn More</a>
+      <a href="https://hacktoolkit.github.io/organize-tabs-chrome-extension/" target="_blank">Learn More</a>
     </p>
 
     <!--


### PR DESCRIPTION
Points plugin URL to https://hacktoolkit.github.io/organize-tabs-chrome-extension/ since the www.hacktoolkit.com website has changed